### PR TITLE
Added options for start and end anchors to regex

### DIFF
--- a/lib/range_regexp.rb
+++ b/lib/range_regexp.rb
@@ -14,8 +14,11 @@ module RangeRegexp
       init_positive_subpatterns
     end
 
-    def convert
+    def convert(options = {})
       @regexp ||= begin
+        line_start_anchor = [:start, :start_and_end].include?(options[:anchor]) ? "^" : ""
+        line_end_anchor   = [:end, :start_and_end].include?(options[:anchor])   ? "$" : ""
+
         negative_subpatterns_only = arrays_diff(@negative_subpatterns, @positive_subpatterns).map do |pattern|
           "-#{pattern}"
         end
@@ -23,7 +26,8 @@ module RangeRegexp
         intersected_subpatterns = (@positive_subpatterns & @negative_subpatterns).map do |pattern|
           "-?#{pattern}"
         end
-        Regexp.new("#{(negative_subpatterns_only + intersected_subpatterns + positive_subpatterns_only).join('|')}")
+        Regexp.new("#{line_start_anchor}#{(negative_subpatterns_only + intersected_subpatterns +
+          positive_subpatterns_only).join('|')}#{line_end_anchor}")
       end
     end
 

--- a/lib/range_regexp.rb
+++ b/lib/range_regexp.rb
@@ -16,9 +16,8 @@ module RangeRegexp
 
     def convert(options = {})
       @regexp ||= begin
-        line_start_anchor = [:start, :start_and_end].include?(options[:anchor]) ? "^" : ""
-        line_end_anchor   = [:end, :start_and_end].include?(options[:anchor])   ? "$" : ""
-
+        line_start_anchor = (options[:anchor].respond_to?(:include?) && options[:anchor].include?(:start)) || options[:anchor].eql?(:start) ? '^' : ''
+        line_end_anchor = (options[:anchor].respond_to?(:include?) && options[:anchor].include?(:end)) || options[:anchor].eql?(:end) ? '$' : ''
         negative_subpatterns_only = arrays_diff(@negative_subpatterns, @positive_subpatterns).map do |pattern|
           "-#{pattern}"
         end

--- a/lib/range_regexp.rb
+++ b/lib/range_regexp.rb
@@ -16,8 +16,10 @@ module RangeRegexp
 
     def convert(options = {})
       @regexp ||= begin
-        line_start_anchor = (options[:anchor].respond_to?(:include?) && options[:anchor].include?(:start)) || options[:anchor].eql?(:start) ? '^' : ''
-        line_end_anchor = (options[:anchor].respond_to?(:include?) && options[:anchor].include?(:end)) || options[:anchor].eql?(:end) ? '$' : ''
+        anchor = Array(options.fetch(:anchor, {}))
+        line_start_anchor = anchor.include?(:start) ? '^' : ''
+        line_end_anchor = anchor.include?(:end) ? '$' : ''
+
         negative_subpatterns_only = arrays_diff(@negative_subpatterns, @positive_subpatterns).map do |pattern|
           "-#{pattern}"
         end

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -14,7 +14,7 @@ describe RangeRegexp::Converter do
       ensure_correct_conversion(-2..0, /-[1-2]|0/)
       ensure_correct_conversion(-3..1, /-[1-3]|[0-1]/)
     end
-    
+
     it 'works as expected for reversed ranges' do
       ensure_correct_conversion(9..-9, /-[1-9]|\d/)
       ensure_correct_conversion(3456..12, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/)
@@ -23,10 +23,10 @@ describe RangeRegexp::Converter do
     end
 
     it 'processes options correctly' do
-      ensure_correct_conversion(-9..9, /^-[1-9]|\d$/, anchor: :start_and_end)
-      ensure_correct_conversion(3456..12, /^1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]$/, anchor: :start_and_end)
-      ensure_correct_conversion(0..-2, /^-[1-2]|0$/, anchor: :start_and_end)
-      ensure_correct_conversion(1..-3, /^-[1-3]|[0-1]$/, anchor: :start_and_end)
+      ensure_correct_conversion(-9..9, /^-[1-9]|\d$/, anchor:[:start, :end])
+      ensure_correct_conversion(3456..12, /^1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]$/, anchor: [:start, :end])
+      ensure_correct_conversion(0..-2, /^-[1-2]|0$/, anchor: [:start, :end])
+      ensure_correct_conversion(1..-3, /^-[1-3]|[0-1]$/, anchor: [:start, :end])
 
       ensure_correct_conversion(-9..9, /^-[1-9]|\d/, anchor: :start)
       ensure_correct_conversion(3456..12, /^1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/, anchor: :start)

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -3,23 +3,40 @@ require 'range_regexp'
 
 describe RangeRegexp::Converter do
   describe '#convert' do
-    def ensure_correct_convertation(range, regexp)
+    def ensure_correct_conversion(range, regexp, options={})
       converter = RangeRegexp::Converter.new(range)
-      assert_equal converter.convert, regexp
+      assert_equal converter.convert(options), regexp
     end
 
     it 'returns a range representation as a regexp' do
-      ensure_correct_convertation(-9..9, /-[1-9]|\d/)
-      ensure_correct_convertation(12..3456, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/)
-      ensure_correct_convertation(-2..0, /-[1-2]|0/)
-      ensure_correct_convertation(-3..1, /-[1-3]|[0-1]/)
+      ensure_correct_conversion(-9..9, /-[1-9]|\d/)
+      ensure_correct_conversion(12..3456, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/)
+      ensure_correct_conversion(-2..0, /-[1-2]|0/)
+      ensure_correct_conversion(-3..1, /-[1-3]|[0-1]/)
     end
     
     it 'works as expected for reversed ranges' do
-      ensure_correct_convertation(9..-9, /-[1-9]|\d/)
-      ensure_correct_convertation(3456..12, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/)
-      ensure_correct_convertation(0..-2, /-[1-2]|0/)
-      ensure_correct_convertation(1..-3, /-[1-3]|[0-1]/)
-    end   
+      ensure_correct_conversion(9..-9, /-[1-9]|\d/)
+      ensure_correct_conversion(3456..12, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/)
+      ensure_correct_conversion(0..-2, /-[1-2]|0/)
+      ensure_correct_conversion(1..-3, /-[1-3]|[0-1]/)
+    end
+
+    it 'processes options correctly' do
+      ensure_correct_conversion(-9..9, /^-[1-9]|\d$/, anchor: :start_and_end)
+      ensure_correct_conversion(3456..12, /^1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]$/, anchor: :start_and_end)
+      ensure_correct_conversion(0..-2, /^-[1-2]|0$/, anchor: :start_and_end)
+      ensure_correct_conversion(1..-3, /^-[1-3]|[0-1]$/, anchor: :start_and_end)
+
+      ensure_correct_conversion(-9..9, /^-[1-9]|\d/, anchor: :start)
+      ensure_correct_conversion(3456..12, /^1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/, anchor: :start)
+      ensure_correct_conversion(0..-2, /^-[1-2]|0/, anchor: :start)
+      ensure_correct_conversion(1..-3, /^-[1-3]|[0-1]/, anchor: :start)
+
+      ensure_correct_conversion(-9..9, /-[1-9]|\d$/, anchor: :end)
+      ensure_correct_conversion(3456..12, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]$/, anchor: :end)
+      ensure_correct_conversion(0..-2, /-[1-2]|0$/, anchor: :end)
+      ensure_correct_conversion(1..-3, /-[1-3]|[0-1]$/, anchor: :end)
+    end
   end
 end


### PR DESCRIPTION
Adds the ability to put the start anchor "^" and end anchor "$" to the resulting regex, so that commands like RangeRegexp::Converter.new(20..89).convert(anchor: :start_and_end) =~  "8080" will return false