### PR TITLE
Options

### DIFF
--- a/lib/range_regexp.rb
+++ b/lib/range_regexp.rb
@@ -4,7 +4,7 @@ require 'range_regexp/version'
 module RangeRegexp
   class Converter
     def initialize(range)
-      @min, @max = range.first, range.last
+      @min, @max = range.first, range.last - (range.exclude_end? ? 1 : 0)
       @min, @max = @max, @min unless range.min
 
       @negative_subpatterns = []
@@ -27,8 +27,8 @@ module RangeRegexp
         intersected_subpatterns = (@positive_subpatterns & @negative_subpatterns).map do |pattern|
           "-?#{pattern}"
         end
-        Regexp.new("#{line_start_anchor}#{(negative_subpatterns_only + intersected_subpatterns +
-          positive_subpatterns_only).join('|')}#{line_end_anchor}")
+        Regexp.new("#{line_start_anchor}(#{(negative_subpatterns_only + intersected_subpatterns +
+          positive_subpatterns_only).join('|')})#{line_end_anchor}")
       end
     end
 

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -14,34 +14,34 @@ describe RangeRegexp::Converter do
     end
 
     it 'returns a range representation as a regexp' do
-      ensure_correct_conversion(-9..9, /-[1-9]|\d/)
-      ensure_correct_conversion(12..3456, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/)
-      ensure_correct_conversion(-2..0, /-[1-2]|0/)
-      ensure_correct_conversion(-3..1, /-[1-3]|[0-1]/)
+      ensure_correct_conversion(-9..9, /(-[1-9]|\d)/)
+      ensure_correct_conversion(12..3456, /(1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6])/)
+      ensure_correct_conversion(-2..0, /(-[1-2]|0)/)
+      ensure_correct_conversion(-3..1, /(-[1-3]|[0-1])/)
     end
 
     it 'works as expected for reversed ranges' do
-      ensure_correct_conversion(9..-9, /-[1-9]|\d/)
-      ensure_correct_conversion(3456..12, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/)
-      ensure_correct_conversion(0..-2, /-[1-2]|0/)
-      ensure_correct_conversion(1..-3, /-[1-3]|[0-1]/)
+      ensure_correct_conversion(9..-9, /(-[1-9]|\d)/)
+      ensure_correct_conversion(3456..12, /(1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6])/)
+      ensure_correct_conversion(0..-2, /(-[1-2]|0)/)
+      ensure_correct_conversion(1..-3, /(-[1-3]|[0-1])/)
     end
 
     it 'processes options correctly' do
-      ensure_correct_conversion(-9..9, /^-[1-9]|\d$/, anchor:[:start, :end])
-      ensure_correct_conversion(3456..12, /^1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]$/, anchor: [:start, :end])
-      ensure_correct_conversion(0..-2, /^-[1-2]|0$/, anchor: [:start, :end])
-      ensure_correct_conversion(1..-3, /^-[1-3]|[0-1]$/, anchor: [:start, :end])
+      ensure_correct_conversion(-9..9, /^(-[1-9]|\d)$/, anchor:[:start, :end])
+      ensure_correct_conversion(3456..12, /^(1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6])$/, anchor: [:start, :end])
+      ensure_correct_conversion(0..-2, /^(-[1-2]|0)$/, anchor: [:start, :end])
+      ensure_correct_conversion(1..-3, /^(-[1-3]|[0-1])$/, anchor: [:start, :end])
 
-      ensure_correct_conversion(-9..9, /^-[1-9]|\d/, anchor: :start)
-      ensure_correct_conversion(3456..12, /^1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/, anchor: :start)
-      ensure_correct_conversion(0..-2, /^-[1-2]|0/, anchor: :start)
-      ensure_correct_conversion(1..-3, /^-[1-3]|[0-1]/, anchor: :start)
+      ensure_correct_conversion(-9..9, /^(-[1-9]|\d)/, anchor: :start)
+      ensure_correct_conversion(3456..12, /^(1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6])/, anchor: :start)
+      ensure_correct_conversion(0..-2, /^(-[1-2]|0)/, anchor: :start)
+      ensure_correct_conversion(1..-3, /^(-[1-3]|[0-1])/, anchor: :start)
 
-      ensure_correct_conversion(-9..9, /-[1-9]|\d$/, anchor: :end)
-      ensure_correct_conversion(3456..12, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]$/, anchor: :end)
-      ensure_correct_conversion(0..-2, /-[1-2]|0$/, anchor: :end)
-      ensure_correct_conversion(1..-3, /-[1-3]|[0-1]$/, anchor: :end)
+      ensure_correct_conversion(-9..9, /(-[1-9]|\d)$/, anchor: :end)
+      ensure_correct_conversion(3456..12, /(1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6])$/, anchor: :end)
+      ensure_correct_conversion(0..-2, /(-[1-2]|0)$/, anchor: :end)
+      ensure_correct_conversion(1..-3, /(-[1-3]|[0-1])$/, anchor: :end)
     end
 
     it 'evaluates strings against regular expression as expected in common cases' do

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -8,6 +8,11 @@ describe RangeRegexp::Converter do
       assert_equal converter.convert(options), regexp
     end
 
+    def ensure_match(options={})
+      converter = RangeRegexp::Converter.new(options[:range])
+      assert_equal options[:expected_result], (converter.convert(options.reject{|k, v| [:input, :range].include?(k)}) === options[:input])
+    end
+
     it 'returns a range representation as a regexp' do
       ensure_correct_conversion(-9..9, /-[1-9]|\d/)
       ensure_correct_conversion(12..3456, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]/)
@@ -37,6 +42,30 @@ describe RangeRegexp::Converter do
       ensure_correct_conversion(3456..12, /1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6]$/, anchor: :end)
       ensure_correct_conversion(0..-2, /-[1-2]|0$/, anchor: :end)
       ensure_correct_conversion(1..-3, /-[1-3]|[0-1]$/, anchor: :end)
+    end
+
+    it 'evaluates strings against regular expression as expected in common cases' do
+      ensure_match(range: -9..9, anchor: [:start, :end], input: '0', expected_result: true)
+      ensure_match(range: -999..456, anchor: [:start, :end], input: '123', expected_result: true)
+      ensure_match(range: -124..243, anchor: [:start, :end], input: '-123', expected_result: true)
+      ensure_match(range: -9..9, anchor: [:start, :end], input: '10', expected_result: false)
+    end
+
+    it 'evaluates strings against regular expressions as expected in corner cases' do
+      ensure_match(range: -10..10, anchor: [:start, :end], input: '-10', expected_result: true)
+      ensure_match(range: -10..10, anchor: [:start, :end], input: '10', expected_result: true)
+      ensure_match(range: -10...10, anchor: [:start, :end], input: '-10', expected_result: true)
+      ensure_match(range: -10...10, anchor: [:start, :end], input: '9', expected_result: true)
+    end
+
+    it 'correctly refuses to match upper bound of exclusive range' do
+      ensure_match(range: -10...10, anchor: [:start, :end], input: '10', expected_result: false)
+    end
+
+    it 'evaluates false when non numerical characters are used with full anchors' do
+      ensure_match(range: -999..999, anchor: [:start, :end], input: 'a12', expected_result: false)
+      ensure_match(range: -999..999, anchor: [:start, :end], input: '1a2', expected_result: false)
+      ensure_match(range: -999..999, anchor: [:start, :end], input: '12a', expected_result: false)
     end
   end
 end


### PR DESCRIPTION
・Fixes issue with the anchor feature that would sometimes result in false positive regex matches
・Added code that decreases upper bound by one if the Range given has the "exclusive end" flag (i.e one defined with the start...end syntax, with three dots
・Add tests to show that these regular expressions were not actually matching correctly, and that they now pass.