### PR TITLE
Improve parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Transform Ruby ranges to regexps
 
-The solution to convert a Ruby `Range` to a `Regexp`
+The solution to convert a numeric Ruby `Range` to a `Regexp`
 
 # Install
 
 In the system:
 
-`gem install range-regexp`
+`gem install range_regexp`
 
 or add the gem to the `Gemfile`:
 
-`gem 'range-regexp'`
+`gem 'range_regexp'`
 
 and then run `bundle install`.
 

--- a/lib/range_regexp.rb
+++ b/lib/range_regexp.rb
@@ -65,7 +65,7 @@ module RangeRegexp
       stops = Set.new
       stops.add(max)
 
-      nines_count = 1
+      nines_count = min % 10 == 0 ? count_nines_at_end(max) + 1 : 1
       stop = fill_by_nines(min, nines_count)
       while min <= stop && stop < max
         stops.add(stop)
@@ -89,6 +89,10 @@ module RangeRegexp
 
     def fill_by_zeros(int, zeros_count)
       int - int % 10 ** zeros_count
+    end
+
+    def count_nines_at_end(int)
+      int.to_s.match(/(9*$)/).to_s.length
     end
 
     def range_to_pattern(start, stop)

--- a/range_regexp.gemspec
+++ b/range_regexp.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest"
 end

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -18,6 +18,8 @@ describe RangeRegexp::Converter do
       ensure_correct_conversion(12..3456, /(1[2-9]|[2-9]\d|[1-9]\d{2}|[1-2]\d{3}|3[0-3]\d{2}|34[0-4]\d|345[0-6])/)
       ensure_correct_conversion(-2..0, /(-[1-2]|0)/)
       ensure_correct_conversion(-3..1, /(-[1-3]|[0-1])/)
+      ensure_correct_conversion(10..39, /([1-3]\d)/)
+      ensure_correct_conversion(11..39, /(1[1-9]|[2-3]\d)/)
     end
 
     it 'works as expected for reversed ranges' do


### PR DESCRIPTION
This improves parsing ranges that start with 0 and end with 9.

Previously, `RangeRegexp::Converter.new(10..39).convert` resulted in `/1\d|[2-3]\d/`. After the changes, the result is `/[1-3]\d/`.